### PR TITLE
Added dynamic JSON modification at the beginning of openaiBot.py

### DIFF
--- a/backend/app/control/bot/openaiBot.py
+++ b/backend/app/control/bot/openaiBot.py
@@ -7,6 +7,7 @@ from app.model.dataModel import MessageModel, SessionModel, VectorDataModel, Rol
 from app.model.agentModel import AgentModel
 from .baseBot import BaseBot
 from app.tool import *
+from app.tool.gtfs import GTFS_data
 
 file_path="storage/tool/tool_register.json"
 
@@ -15,6 +16,12 @@ our_api_request_forced_a_tool_call = False
 # Load the JSON data from the file
 with open(file_path, 'r') as file:
     tools = json.load(file)
+    
+# Dynamically update tools before tool calls are invoked
+for tool in tools:
+        if tool['function']['name'] == 'get_all_stop_times':
+            tool['function']['parameters']['properties']['stop_name']['enum'] = GTFS_data().stops['stop_name']
+            break
 
 class OpenAIBot(BaseBot):
     def __init__(self, api_key):

--- a/backend/storage/tool/tool_register.json
+++ b/backend/storage/tool/tool_register.json
@@ -47,11 +47,7 @@
                 "properties": {
                     "stop_name": {
                         "type": "string",
-                        "enum": [
-                            "centrepoint Metro Station 1",
-                            "Emirates Metro Station 1",
-                            "Airport Terminal 3 Metro Station 1"
-                        ],
+                        "enum": [],
                         "description": "The name of the public transport station"
                     }
                 },


### PR DESCRIPTION
Added a simple dynamic JSON update that will be invoked at the beginning of the program's initiation. 

This doesn't apply to new chatbot instances, which means the JSON won't be dynamically updated when a new chatbot instance is created. The purpose is to prevent repetitive database access, In the future, we can make a multithreaded thing which updates the JSON by reading from the database after every certain period of time.

Feel free to further improve this fix, it is indeed a temporary solution. 